### PR TITLE
allow to install for magento 2.4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "magento/framework": "^100.1|^101.0|^102.0"
+        "magento/framework": "^100.1|^101.0|^102.0|^103.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
I've tested with 2.4 and it is working. Only the composer constraint prevents the installation.